### PR TITLE
rename test files so they are easily discoverable; pep8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,22 +4,20 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(packages=find_packages(),
-    name="hcuppy",
-    version="0.0.7",
-    description="hcuppy is a Python implementation of HCUP Tools and Software",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author="Yubin Park",
-    author_email="yubin.park@gmail.com",
-    url="https://github.com/yubin-park/hcuppy",
-    license="Apaceh 2.0", 
-    install_requires = [],
-    include_package_data=True,
-    package_data={"": ["*.txt", "*.csv"]},
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: OS Independent"
-    ])
-
-
+      name="hcuppy",
+      version="0.0.7",
+      description="hcuppy is a Python implementation of HCUP Tools and Software",
+      long_description=long_description,
+      long_description_content_type="text/markdown",
+      author="Yubin Park",
+      author_email="yubin.park@gmail.com",
+      url="https://github.com/yubin-park/hcuppy",
+      license="Apache 2.0",
+      install_requires=[],
+      include_package_data=True,
+      package_data={"": ["*.txt", "*.csv"]},
+      classifiers=[
+          "Programming Language :: Python :: 3",
+          "License :: OSI Approved :: Apache Software License",
+          "Operating System :: OS Independent"
+      ])

--- a/tests/test_cci.py
+++ b/tests/test_cci.py
@@ -1,6 +1,7 @@
 import unittest
 from hcuppy.cci import CCIEngine
 
+
 class TestCCIEngine(unittest.TestCase):
 
     def test_ccimapping(self):
@@ -15,7 +16,3 @@ class TestCCIEngine(unittest.TestCase):
 
         self.assertTrue(ce.get_cci("E119")["is_chronic"])
         self.assertTrue(ce.is_chronic("E119"))
-
-if __name__=="__main__":
-    unittest.main()
-

--- a/tests/test_ccs.py
+++ b/tests/test_ccs.py
@@ -1,6 +1,7 @@
 import unittest
 from hcuppy.ccs import CCSEngine
 
+
 class TestCCSEngine(unittest.TestCase):
 
     def test_ccsmapping(self):
@@ -21,14 +22,6 @@ class TestCCSEngine(unittest.TestCase):
         ccs_lst = cepr.get_ccs(["00800ZZ"])
         self.assertTrue("1" in {ccs["ccs"] for ccs in ccs_lst})
 
-
         cepr = CCSEngine(mode="pr-cpt")
         ccs_lst = cepr.get_ccs(["0001M"])
         self.assertTrue("234" in {ccs["ccs"] for ccs in ccs_lst})
-
-       
-
-
-if __name__=="__main__":
-    unittest.main()
-

--- a/tests/test_cpt.py
+++ b/tests/test_cpt.py
@@ -1,6 +1,7 @@
 import unittest
 from hcuppy.cpt import CPT
 
+
 class TestLicense(unittest.TestCase):
 
     def test_license(self):
@@ -10,8 +11,4 @@ class TestLicense(unittest.TestCase):
     def test_section(self):
         cpt = CPT()
         out = cpt.get_cpt_section("E0100")
-        self.assertTrue(out["sect"]=="HCPCS2-E")
-
-if __name__=="__main__":
-    unittest.main()
-
+        self.assertTrue(out["sect"] == "HCPCS2-E")

--- a/tests/test_elixhauser.py
+++ b/tests/test_elixhauser.py
@@ -1,6 +1,7 @@
 import unittest
 from hcuppy.elixhauser import ElixhauserEngine
 
+
 class TestElixhauserEngine(unittest.TestCase):
 
     def test_elixhauser(self):
@@ -11,12 +12,11 @@ class TestElixhauserEngine(unittest.TestCase):
         self.assertEqual(out["mrtlt_scr"], 9)
 
         out = ee.get_elixhauser(["M545"])
-        self.assertTrue(len(out["cmrbdt_lst"])==0)
+        self.assertTrue(len(out["cmrbdt_lst"]) == 0)
 
         out = ee.get_elixhauser(["D473"])
-        self.assertTrue(len(out["cmrbdt_lst"])==0)
+        self.assertTrue(len(out["cmrbdt_lst"]) == 0)
 
 
-if __name__=="__main__":
+if __name__ == "__main__":
     unittest.main()
-

--- a/tests/test_prcls.py
+++ b/tests/test_prcls.py
@@ -1,16 +1,12 @@
 import unittest
 from hcuppy.prcls import PrClsEngine
 
+
 class TestPrClsEngine(unittest.TestCase):
 
     def test_prclsmapping(self):
         pce = PrClsEngine()
         prcls_lst = pce.get_prcls(["B231Y0Z", "randomstring"])
         self.assertEqual(prcls_lst[0]["desc"], "Minor Diagnostic")
-        self.assertEqual(pce.get_prcls("B231Y0Z")["desc"], 
-                            "Minor Diagnostic")
-
-
-if __name__=="__main__":
-    unittest.main()
-
+        self.assertEqual(pce.get_prcls("B231Y0Z")["desc"],
+                         "Minor Diagnostic")

--- a/tests/test_sflag.py
+++ b/tests/test_sflag.py
@@ -1,6 +1,7 @@
 import unittest
 from hcuppy.sflag import SFlagEngine
 
+
 class TestSFlagEngine(unittest.TestCase):
 
     def test_sflagmapping(self):
@@ -10,7 +11,3 @@ class TestSFlagEngine(unittest.TestCase):
         out = sfe.get_sflag(["69970", "randomstring"])
         self.assertEqual(out[0]["flag"], "2")
         self.assertEqual(out[1]["flag"], "na")
-
-if __name__=="__main__":
-    unittest.main()
-

--- a/tests/test_uflag.py
+++ b/tests/test_uflag.py
@@ -1,21 +1,17 @@
 import unittest
 from hcuppy.uflag import UFlagEngine
 
+
 class TestUFlagEngine(unittest.TestCase):
 
     def test_uflagmapping(self):
         ufe = UFlagEngine()
         self.assertTrue("Blood" in ufe.get_uflag(rev_lst=["0380"]))
-        self.assertTrue("Chest X-Ray" in 
+        self.assertTrue("Chest X-Ray" in
                         ufe.get_uflag(pr_lst=["BB0DZZZ"]))
-        self.assertTrue("Computed Tomography Scan" in 
+        self.assertTrue("Computed Tomography Scan" in
                         ufe.get_uflag(pr_lst=["B02000Z"]))
 
         uflag_lst = ufe.get_uflag(rev_lst=["0380"], pr_lst=["BB0DZZZ"])
         self.assertTrue("Blood" in uflag_lst)
         self.assertTrue("Chest X-Ray" in uflag_lst)
-
-if __name__=="__main__":
-    unittest.main()
-
-


### PR DESCRIPTION
Hi Yubin,
With these changes, tests can be run by:
`python -m unittest discover tests`
Thanks,
Dan